### PR TITLE
Use built-in `Item.fromDropData` over custom drop->item resolution

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -2055,16 +2055,7 @@ const API = {
 
         if (data.type !== "Item") return;
 
-        let itemData;
-        if (data.pack) {
-            const uuid = `Compendium.${data.pack}.${data.id}`;
-            const item = await fromUuid(uuid);
-            itemData = item.toObject();
-        } else if (data.id) {
-            itemData = game.items.get(data.id)?.toObject();
-        } else {
-            itemData = data.data;
-        }
+        const itemData = (await Item.fromDropData(data)).toObject();
 
         if (!itemData) {
             console.error(data);


### PR DESCRIPTION
As a module developer, I want to be able to patch `Item.fromDropData` to add custom functionality without creating inconsistencies/breaking Item Piles. 

(Please note: I have not tested this beyond the basic case/my use case, nor did I scan through Item Piles source for similar instances which could also be replaced. Caveat emptor.)