### PR TITLE
Avoid crash on creating item pile with 2+ items

### DIFF
--- a/scripts/lib/lib.js
+++ b/scripts/lib/lib.js
@@ -199,7 +199,7 @@ export function getItemPileTokenImage(target, { data = false, items = false, cur
             ? items[0].img
             : currencies[0].img;
     } else if (data.displayOne && numItems > 1) {
-        img = pileDocument.actor.data.token.img;
+        img = (pileDocument.actor ?? pileDocument).data.token.img;
     }
 
     if (data.isContainer) {


### PR DESCRIPTION
In some contexts, `pileDocument` is an `Actor5e`. In other contexts, it is a `TokenDocument`. Tolerate either case.

Closes #74