### PR TITLE
Corrected currency image extension for SF.

### DIFF
--- a/scripts/systems/sfrpg.js
+++ b/scripts/systems/sfrpg.js
@@ -21,12 +21,12 @@ export default {
         {
             name: "SFRPG.Currencies.Credits",
             path: "data.currency.credit",
-            img: "systems/sfrpg/icons/equipment/goods/credstick.jpg"
+            img: "systems/sfrpg/icons/equipment/goods/credstick.webp"
         },
         {
             name: "SFRPG.Currencies.UPBs",
             path: "data.currency.upb",
-            img: "systems/sfrpg/icons/equipment/goods/upb.jpg"
+            img: "systems/sfrpg/icons/equipment/goods/upb.webp"
         }
     ]
 }


### PR DESCRIPTION
The Starfinder RPG system recently converted their images to webp, this corrects the currency icons referenced in the module to webp.