### PR TITLE
Add customizable decimal digits for currencies

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -492,6 +492,10 @@
         "Label": "Configure Currencies",
         "Hint": "This setting define the currencies that are eligible for pickup, which may not be actual items but numerical inputs on the character sheet."
       },
+      "CurrencyDecimalDigits": {
+        "Title": "Currency Decimal Digits",
+        "Hint": "This setting defines the lowest decimal digit your currencies round to. For example in a modern setting with modern currencies, '0.01' allows for two decimal digits. In a setting without decimal digits, simply put a '1'."
+      },
       "ItemFilters": {
         "Title": "Item filters",
         "Label": "Configure Item Filters",

--- a/src/applications/settings-app/Setting.svelte
+++ b/src/applications/settings-app/Setting.svelte
@@ -34,7 +34,7 @@
 
     {:else if data.type === Number}
 
-      <input type="number" bind:value={data.value} class:invalid={!data.value && data.value !== 0}>
+      <input type="number" bind:value={data.value} step={data.step} min={data.min} max={data.max} class:invalid={!data.value && data.value !== 0}>
 
     {:else}
 

--- a/src/applications/settings-app/settings-shell.svelte
+++ b/src/applications/settings-app/settings-shell.svelte
@@ -165,6 +165,7 @@
           <Setting bind:data="{settings[SETTINGS.ACTOR_CLASS_TYPE]}" options={game.system.template.Actor.types}/>
           <Setting bind:data="{settings[SETTINGS.ITEM_QUANTITY_ATTRIBUTE]}"/>
           <Setting bind:data="{settings[SETTINGS.ITEM_PRICE_ATTRIBUTE]}"/>
+          <Setting bind:data="{settings[SETTINGS.CURRENCY_DECIMAL_DIGITS]}"/>
           <SettingButton bind:data="{settings[SETTINGS.CURRENCIES]}"/>
           <SettingButton bind:data="{settings[SETTINGS.ITEM_FILTERS]}"/>
           <SettingButton bind:data="{settings[SETTINGS.ITEM_SIMILARITIES]}"/>

--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -21,6 +21,7 @@ const SETTINGS = {
   
   // System Settings
   CURRENCIES: "currencies",
+  CURRENCY_DECIMAL_DIGITS: "currencyDecimalDigits",
   ITEM_FILTERS: "itemFilters",
   ACTOR_CLASS_TYPE: "actorClassType",
   ITEM_QUANTITY_ATTRIBUTE: "itemQuantityAttribute",
@@ -61,6 +62,19 @@ const SETTINGS = {
       system: true,
       default: SYSTEMS.DATA.CURRENCIES,
       type: Object
+    },
+
+    [SETTINGS.CURRENCY_DECIMAL_DIGITS]: {
+      name: "ITEM-PILES.Settings.CurrencyDecimalDigits.Title",
+      hint: "ITEM-PILES.Settings.CurrencyDecimalDigits.Hint",
+      scope: "world",
+      config: false,
+      system: true,
+      default: 0.00001,
+      step: 0.00001,
+      min: 0,
+      max: 1,
+      type: Number
     },
     
     [SETTINGS.ITEM_FILTERS]: {

--- a/src/helpers/pile-utilities.js
+++ b/src/helpers/pile-utilities.js
@@ -4,6 +4,7 @@ import * as Helpers from "./helpers.js";
 import { SYSTEMS } from "../systems.js";
 import { hotkeyState } from "../hotkeys.js";
 import { getItemCost } from "./utilities.js";
+import SETTINGS from "../constants/settings.js";
 
 function getFlagData(inDocument, flag, defaults, existing = false) {
   const defaultFlags = foundry.utils.duplicate(defaults);
@@ -435,7 +436,7 @@ export function getMerchantModifiersForActor(merchant, { item = false, actor = f
 }
 
 function getSmallestExchangeRate(currencies) {
-  return currencies.length > 1 ? Math.min(...currencies.map(currency => currency.exchangeRate)) : 0.00001;
+  return currencies.length > 1 ? Math.min(...currencies.map(currency => currency.exchangeRate)) : Helpers.getSetting(SETTINGS.CURRENCY_DECIMAL_DIGITS);
 }
 
 function getExchangeRateDecimals(smallestExchangeRate) {


### PR DESCRIPTION
This PR adds a customizable way to change the maximum decimal digits for currency in the setting. This way modern settings can round their prices to the closest 0.01 for example, while classic fantasy settings could round their prices to the closest integer.

I didn't work with Svelte before, so if I did make any mistakes, please let me know and I will correct it. I tried to be as clean as possible and do no unnecessary changes.

What's _not_ included (but could be done if wanted): Enforce the display of trailing zeroes for modern currencies. So 50ct would be shown as $0.50 and not $0.5 as right now. Let me know if I should look into that as well. I personally think it would look nicer than right now, but it would introduce a second Setting for a boolean to disable or enable the formatting.