### PR TITLE
Update cyphersystem.js

### DIFF
--- a/src/systems/cyphersystem.js
+++ b/src/systems/cyphersystem.js
@@ -1,9 +1,9 @@
 export default {
 
-  "VERSION": "1.0.0",
+  "VERSION": "1.0.1",
 
   // The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
-  "ACTOR_CLASS_TYPE": "marker",
+  "ACTOR_CLASS_TYPE": "pc",
 
   // The item quantity attribute is the path to the attribute on items that denote how many of that item that exists
   "ITEM_QUANTITY_ATTRIBUTE": "system.basic.quantity",
@@ -25,6 +25,72 @@ export default {
   // Currencies in item piles is a versatile system that can accept actor attributes (a number field on the actor's sheet) or items (actual items in their inventory)
   // In the case of attributes, the path is relative to the "actor.system"
   // In the case of items, it is recommended you export the item with `.toObject()` and strip out any module data
-  "CURRENCIES": []
-
+  "CURRENCIES": [
+    {
+      type: "attribute",
+      name: "Adamantine pieces",
+      img: "icons/commodities/currency/coin-embossed-ruby-gold.webp",
+      abbreviation: "{#} ap",
+      data: {
+        path: "system.settings.equipment.currency.quantity6"
+      },
+      primary: false,
+      exchangeRate: 1000
+    },
+    {
+      type: "attribute",
+      name: "Mithral pieces",
+      img: "icons/commodities/currency/coin-embossed-unicorn-silver.webp",
+      abbreviation: "{#} mp",
+      data: {
+        path: "system.settings.equipment.currency.quantity5"
+      },
+      primary: false,
+      exchangeRate: 100
+    },
+    {
+      type: "attribute",
+      name: "Platinum pieces",
+      img: "icons/commodities/currency/coin-engraved-moon-silver.webp",
+      abbreviation: "{#} pp",
+      data: {
+        path: "system.settings.equipment.currency.quantity4"
+      },
+      primary: false,
+      exchangeRate: 10
+    },
+    {
+      type: "attribute",
+      name: "Gold pieces",
+      img: "icons/commodities/currency/coins-plain-gold.webp",
+      abbreviation: "{#} gp",
+      data: {
+        path: "system.settings.equipment.currency.quantity3"
+      },
+      primary: true,
+      exchangeRate: 1
+    },
+    {
+      type: "attribute",
+      name: "Silver pieces",
+      img: "icons/commodities/currency/coins-engraved-face-silver.webp",
+      abbreviation: "{#} sp",
+      data: {
+        path: "system.settings.equipment.currency.quantity2"
+      },
+      primary: false,
+      exchangeRate: 0.1
+    },
+    {
+      type: "attribute",
+      name: "Copper pieces",
+      img: "icons/commodities/currency/coins-engraved-copper.webp",
+      abbreviation: "{#} cp",
+      data: {
+        path: "system.settings.equipment.currency.quantity1"
+      },
+      primary: false,
+      exchangeRate: 0.01
+    }
+  ]
 }


### PR DESCRIPTION
Hey there!

I’m sorry, I had a misunderstanding on how Item Piles is supposed to work and this would be my proposal to fix the error. 

First, the Item Pile actor should be a PC so that it can hold currencies.

Second, against my original proposal where there weren’t any default currencies set, Cypher being a generic system and currency being highly setting dependent, I’d now propose to use default fantasy currencies. This way, it’s easier for the users to edit that for their setting instead of needing to create it on their own completely.

I was a bit unsure about the version.

Thank you for considering. I also hope that it’s okay to PR this, instead of creating an issue. I thought I might save you some work this way, but I’d be happy to create an issue for it as well.