### PR TITLE
Add support for Dark Heresy 2nd Edition

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,7 @@ Item Piles is designed to work in all systems, but may require some setup for it
 - [Pokemon Tabletop United](https://ptufvtt.com/)
 - [Dungeon Crawl Classics](https://foundryvtt.com/packages/dcc/)
 - [Level Up: Advanced 5th Edition](https://foundryvtt.com/packages/a5e)
+- [Dark Heresy 2nd Edition](https://foundryvtt.com/packages/dark-heresy)
 
 ## Externally support systems
 

--- a/src/systems.js
+++ b/src/systems.js
@@ -27,6 +27,7 @@ import cyphersystem from "./systems/cyphersystem.js";
 import ptu from "./systems/ptu.js";
 import dcc from "./systems/dcc.js";
 import a5e from "./systems/a5e.js";
+import darkHeresy2e from "./systems/dark-heresy.js";
 // ↑ IMPORT SYSTEMS HERE ↑
 
 /**
@@ -118,6 +119,9 @@ export const SYSTEMS = {
     },
     "a5e": {
       "latest": a5e
+    },
+    "dark-heresy": {
+      "latest": darkHeresy2e
     }
     // ↑ ADD SYSTEMS HERE ↑
   },

--- a/src/systems/dark-heresy.js
+++ b/src/systems/dark-heresy.js
@@ -1,0 +1,36 @@
+export default {
+
+  "VERSION": "1.0.0",
+
+  // The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
+  "ACTOR_CLASS_TYPE": "acolyte",
+
+  // The item quantity attribute is the path to the attribute on items that denote how many of that item that exists
+  "ITEM_QUANTITY_ATTRIBUTE": "system.quantity",
+
+  // The item price attribute is the path to the attribute on each item that determine how much it costs
+  "ITEM_PRICE_ATTRIBUTE": "",
+
+  // Item filters actively remove items from the item pile inventory UI that users cannot loot, such as spells, feats, and classes
+  "ITEM_FILTERS": [
+    {
+      "path": "type",
+      "filters": "specialAbility, aptitude, talent, psychicPower, trait"
+    },
+    {
+      "path": "system.installed",
+      "filters": "installed"
+    }
+  ],
+
+  // Item similarities determines how item piles detect similarities and differences in the system
+  "ITEM_SIMILARITIES": [],
+
+  // Currencies in item piles is a versatile system that can accept actor attributes (a number field on the actor's sheet) or items (actual items in their inventory)
+  // In the case of attributes, the path is relative to the "actor.system"
+  // In the case of items, it is recommended you export the item with `.toObject()` and strip out any module data
+  "CURRENCIES": [],
+
+  "CURRENCY_DECIMAL_DIGITS": 0.00001
+}
+  


### PR DESCRIPTION
Some open questions.

The id of the system is `dark-heresy`, which is a bit unfortunate as it is the second edition...
The system has no currency as far as I could tell, hence I left the price attribute and currency object empty

Has support that installed cybernetics cannot be looted by default.

Known issues so far, which I do not know how to solve with the configuration, when hitting the `Reset Settings" button, this error is displayed in the console. 
![image](https://user-images.githubusercontent.com/8259498/226315992-3d15c52b-8bf4-4b76-9590-36404cc611e8.png)

It points towards this button inside the menu
`<SettingButton key={SETTINGS.PRICE_PRESETS} bind:data="{settings[SETTINGS.PRICE_PRESETS]}"/>`