### PR TITLE
depreciated warning fix: game.system.name

### DIFF
--- a/src/API/api.js
+++ b/src/API/api.js
@@ -389,7 +389,7 @@ class API {
 
     SYSTEMS.addSystem(data);
 
-    Helpers.debug(`Registered system settings for ${game.system.name}`, data)
+    Helpers.debug(`Registered system settings for ${game.system.id}`, data)
 
   }
 


### PR DESCRIPTION
reference is now game.system.id for v10 forward