### PR TITLE
fix: pf1 item value was based on stack rather than singular item

### DIFF
--- a/src/systems/pf1.js
+++ b/src/systems/pf1.js
@@ -1,6 +1,6 @@
 export default {
 
-  "VERSION": "1.0.4",
+  "VERSION": "1.0.5",
 
   // The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
   "ACTOR_CLASS_TYPE": "npc",
@@ -14,7 +14,14 @@ export default {
   // This function is an optional system handler that specifically transforms an item's price into a more unified numeric format
   "ITEM_COST_TRANSFORMER": (item, currencies) => {
     // Account for wand charges, broken condition, and other traits that are not reflected in base price.
-    return item.getValue({ sellValue: 1.0 });
+    // Spoof quantity to 1 temporarily
+    const origQuantity = item.system.quantity;
+    item.system.quantity = 1;
+    // Get actual value
+    const value = item.getValue({ sellValue: 1.0 });
+    // Restore quantity
+    item.system.quantity = origQuantity;
+    return value;
   },
 
   // Item types and the filters actively remove items from the item pile inventory UI that users cannot loot, such as spells, feats, and classes


### PR DESCRIPTION
Fix for a pricing bug I introduced with #433

I had incorrectly assumed the items would have quantity 1 in the item and the merchant's quantity was tracked by some other means, but this was not the case.

This spoofs quantity of 1 on the item for the duration of determining its value and restores it back, allowing stacks to correctly display per item price.

The system's function currently does not support getting singular item's value more easily.