### PR TITLE
fix better rolltables loot generation

### DIFF
--- a/src/helpers/pile-utilities.js
+++ b/src/helpers/pile-utilities.js
@@ -1769,11 +1769,11 @@ export async function rollTable({
 	if (game.modules.get("better-rolltables")?.active) {
 		results = (await game.betterTables.roll(table)).itemsData.map(result => {
 			return {
-				documentCollection: result.compendiumName || result.documentName,
-				documentId: result.item.id,
-				text: result.item.text || result.item.name,
-				img: result.item.img,
-				quantity: result.quantity
+				documentCollection: result.documentCollection,
+				documentId: result.documentId,
+				text: result.text || result.name,
+				img: result.img,
+				quantity: 1
 			}
 		})
 	} else {


### PR DESCRIPTION
loot generation did not seem to work, so I debuged what the _result_ object holded with better rolltables 2.0.31, and fixed it