### PR TITLE
Add utility method getStringFromCurrencies

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@
   * [removeCurrencies](#removeCurrencies)
   * [transferCurrencies](#transferCurrencies)
   * [transferAllCurrencies](#transferAllCurrencies)
+  * [getCurrenciesAbbreviations](#getCurrenciesAbbreviations)
   * [getStringFromCurrencies](#getStringFromcurrencies)
   * [getCurrenciesFromString](#getCurrenciesFromString)
   * [calculateCurrencies](#calculateCurrencies)
@@ -929,21 +930,34 @@ Transfers all currencies between the source and the target.
 
 ---
 
-### getStringFromCurrencies
+### getCurrenciesAbbreviations
 
-`game.itempiles.API.getStringFromCurrencies(currencies)` ⇒ `object`
+`game.itempiles.API.getCurrenciesAbbreviations()` ⇒ `Array.<string>`
 
 Turns an array containing the data and quantities for each currency into a string of currencies
 
-**NOTE:** This is a utility method for use the other currencies api methods based on a string input.
+**NOTE:** This is just a utility method for module intercompatibility to use the other currencies api methods based on a string input.
+
+**Returns**: `Array.<string>` - An array of string containing the abbreviation for each currency registered (eg, ["GP","SP"])
+
+---
+
+### getStringFromCurrencies
+
+`game.itempiles.API.getStringFromCurrencies(currencies)` ⇒ `string`
+
+Turns an array containing the data and quantities for each currency into a string of currencies
+
+**NOTE:** This is just a utility method for module intercompatibility to use the other currencies api methods based on a string input.
 
 **Returns**: `string` - A string of currencies to add (eg, "5gp 25sp")
 
-| Param              | Type     | Default | Description                                    |
-|--------------------|----------|---------|------------------------------------------------|
-| currencies         | `Array`  |         | An array of object containing the data and quantity for each currency |
-| currencies[].value | `number` |         | The quantity of the currency         |
-| currencies[].denom | `string` |         | The denomination of the currency     |
+| Param                     | Type     | Default | Description                                    |
+|---------------------------|----------|---------|------------------------------------------------|
+| currencies                | `Array`  |         | An array of object containing the data and quantity for each currency |
+| currencies[].cost         | `number` |         | The quantity of the currency         |
+| currencies[].abbreviation | `string` |         | The abbreviation of the currency, which are usually {#}GP, which when {#} is replaced with the number it becomes 5GP.     |
+| currencies[].percent      | `boolean`|         | The cost of the currency is in percentage (NOTE: for work the 'abbreviation' property must includes '%' substring)  |
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -65,6 +65,7 @@
   * [removeCurrencies](#removeCurrencies)
   * [transferCurrencies](#transferCurrencies)
   * [transferAllCurrencies](#transferAllCurrencies)
+  * [getStringFromCurrencies](#getstringfromcurrencies)
   * [getCurrenciesFromString](#getCurrenciesFromString)
   * [calculateCurrencies](#calculateCurrencies)
   * [getPaymentData](#getPaymentData)
@@ -925,6 +926,24 @@ Transfers all currencies between the source and the target.
 | target                  | `Actor/Token/TokenDocument` |         | The actor to receive all the currencies   |
 | options                 | `object`                    |         | Options to pass to the function           |
 | [options.interactionId] | `string/boolean`            | `false` | The interaction ID of this action         |
+
+---
+
+### getStringFromCurrencies
+
+`game.itempiles.API.getStringFromCurrencies(currencies)` ⇒ `object`
+
+Turns an array containing the data and quantities for each currency into a string of currencies
+
+**NOTE:** This is a utility method for use the other currencies api methods based on a string input.
+
+**Returns**: `string` - A string of currencies to add (eg, "5gp 25sp")
+
+| Param              | Type     | Default | Description                                    |
+|--------------------|----------|---------|------------------------------------------------|
+| currencies         | `Array`  |         | An array of object containing the data and quantity for each currency |
+| currencies[].value | `number` |         | The quantity of the currency         |
+| currencies[].denom | `string` |         | The denomination of the currency     |
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -65,7 +65,7 @@
   * [removeCurrencies](#removeCurrencies)
   * [transferCurrencies](#transferCurrencies)
   * [transferAllCurrencies](#transferAllCurrencies)
-  * [getStringFromCurrencies](#getstringFromcurrencies)
+  * [getStringFromCurrencies](#getStringFromcurrencies)
   * [getCurrenciesFromString](#getCurrenciesFromString)
   * [calculateCurrencies](#calculateCurrencies)
   * [getPaymentData](#getPaymentData)

--- a/docs/api.md
+++ b/docs/api.md
@@ -65,7 +65,7 @@
   * [removeCurrencies](#removeCurrencies)
   * [transferCurrencies](#transferCurrencies)
   * [transferAllCurrencies](#transferAllCurrencies)
-  * [getStringFromCurrencies](#getstringfromcurrencies)
+  * [getStringFromCurrencies](#getstringFromcurrencies)
   * [getCurrenciesFromString](#getCurrenciesFromString)
   * [calculateCurrencies](#calculateCurrencies)
   * [getPaymentData](#getPaymentData)

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -1658,15 +1658,50 @@ class API {
 	}
 
 	/**
+	 * Return all th registered currencies abbreviations
+	 * @returns {Array<string>}                                 An array of string containing the abbreviation for each currency registered
+	 */
+	static getCurrenciesAbbreviations() {
+		return PileUtilities.getCurrenciesAbbreviations();
+	}
+
+	/**
 	 * Turns an array containing the data and quantities for each currency into a string of currencies
 	 *
-	 * @param {Array<object>} currencies                       An array of object containing the data and quantity for each currency
-|    * @param {number} currencies[].value                      The quantity of the currency
-|    * @param {string} currencies[].denom                      The denomination of the currency  
-	 *
-	 * @returns {string}                                       An array of object containing the data and quantity for each currency
+	 * @param {Array<object>} currencies                      An array of object containing the data and quantity for each currency
+|    * @param {number} currencies[].cost                      The cost of the currency
+|    * @param {string} currencies[].denom                     The abbreviation of the currency, which are usually {#}GP, which when {#} is replaced with the number it becomes 5GP.  
+	 * @param {string} currencies[].percent                   The cost of  the currency is in percentage (for work the 'abbreviation' property must includes '%' substring)
+	 * @returns {string}                                      An array of object containing the data and quantity for each currency
 	 */
 	static getStringFromCurrencies(currencies) {
+		if (!currencies) {
+			throw Helpers.custom_error(`getStringFromCurrencies | currencies must be defined`, true);
+		}
+		if (typeof currencies === "string") {
+			throw Helpers.custom_error(`getStringFromCurrencies | currencies can't be of type string`, true);
+		}
+		if (!Array.isArray(currencies)) {
+			throw Helpers.custom_error(`getStringFromCurrencies | currencies must be of type array`, true);
+		}
+		if (currencies.length === 0) {
+			throw Helpers.custom_error(`getStringFromCurrencies | currencies must be a not empty array`, true);
+		}
+		currencies.forEach(currency => {
+			if (typeof currency !== "object") {
+				throw Helpers.custom_error("setCurrencies | each entry in inCurrencies must be of type object");
+			}
+			if (typeof currency.cost !== "number") {
+				throw Helpers.custom_error("getStringFromCurrencies | currency.cost must be of type number");
+			}
+			// Is optional
+			// if (typeof currency.percent !== "boolean") {
+			// 	throw Helpers.custom_error("getStringFromCurrencies | currency.percent must be of type boolean");
+			// }
+			if (typeof currency.abbreviation !== "string") {
+				throw Helpers.custom_error("getStringFromCurrencies | currency.abbreviation must be of type string");
+			}
+		});
 		return PileUtilities.getStringFromCurrencies(currencies);
 	}
 

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -1658,6 +1658,19 @@ class API {
 	}
 
 	/**
+	 * Turns an array containing the data and quantities for each currency into a string of currencies
+	 *
+	 * @param {Array<object>} currencies                       An array of object containing the data and quantity for each currency
+|    * @param {number} currencies[].value                      The quantity of the currency
+|    * @param {string} currencies[].denom                      The denomination of the currency  
+	 *
+	 * @returns {string}                                       An array of object containing the data and quantity for each currency
+	 */
+	static getStringFromCurrencies(currencies) {
+		return PileUtilities.getStringFromCurrencies(currencies);
+	}
+
+	/**
 	 * Turns a string of currencies into an array containing the data and quantities for each currency
 	 *
 	 * @param {string} currencies                               A string of currencies to convert (eg, "5gp 25sp")

--- a/src/helpers/pile-utilities.js
+++ b/src/helpers/pile-utilities.js
@@ -778,6 +778,36 @@ export function getPriceArray(totalCost, currencies) {
 	});
 }
 
+export function getStringFromCurrencies(currencies) {
+	let priceString = "";
+	if (!currencies) {
+		throw Helpers.custom_error(`getStringFromCurrencies | currencies must be defined`, true);
+	}
+	if (typeof currencies === "string") {
+		throw Helpers.custom_error(`getStringFromCurrencies | currencies can't be of type string`, true);
+	}
+	if (!Array.isArray(currencies)) {
+        throw Helpers.custom_error(`getStringFromCurrencies | currencies must be of type array`, true);
+    }
+	if (currencies.length === 0) {
+		throw Helpers.custom_error(`getStringFromCurrencies | currencies must be a not empty array`, true);
+	}
+	for(const currency of currencies){
+		if (typeof currency !== "object") {
+			throw Helpers.custom_error(`getStringFromCurrencies | currency element must be of type object ${currency}`, true);
+		}
+		const value = currency.value;
+		const denom = currency.denom;
+		if(Helpers.isRealNumber(value) && denom?.length > 0) {
+			priceString = priceString + value + "" + denom + " "
+		} else {
+			Helpers.custom_warning(`getStringFromCurrencies | The currency element is not valid with value '${value}' and denomination '${denom}'`, false);
+		}
+	}
+	priceString = priceString.trim();
+	return priceString;
+}
+
 export function getPriceFromString(str, currencyList = false) {
 
 	if (!currencyList) {


### PR DESCRIPTION
I decided to kill lazy money in favor of item piles.

During the development of integration with other modules I noticed that they almost all are based on the concept of value+denominatiom, in order not to rewrite the same code several times I thought to try to insert the utility method directly on Item Piles, also because I don't know if there are necessary controls on currency denominations present on game.itempiles.API.CURRENCIES or game.itempiles.API.SECONDARY_CURRENCIES.
