### PR TITLE
Changes defaults for SWADE

### DIFF
--- a/src/systems/swade.js
+++ b/src/systems/swade.js
@@ -3,7 +3,7 @@ export default {
 	"VERSION": "1.0.4",
 
 	// The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
-	"ACTOR_CLASS_TYPE": "character",
+	"ACTOR_CLASS_TYPE": "npc",
 
 	// The item quantity attribute is the path to the attribute on items that denote how many of that item that exists
 	"ITEM_QUANTITY_ATTRIBUTE": "system.quantity",
@@ -15,7 +15,7 @@ export default {
 	"ITEM_FILTERS": [
 		{
 			"path": "type",
-			"filters": "edge,hindrance,skill,power,ability"
+			"filters": "edge,hindrance,skill,power,ability,action"
 		}
 	],
 


### PR DESCRIPTION
- Changes `ACTOR_CLASS_TYPE` to `npc`
- Adds "action" to `filters` string (Fixes #506).