### PR TITLE
Externalize some utilities method to the api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -83,6 +83,7 @@
   * [rollItemTable](#rollItemTable)
   * [getPricesForItem](#getPricesForItem)
   * [tradeItems](#tradeItems)
+  * [getItemTypesThatCanStack](#getItemTypesThatCanStack)
 
 ## System settings methods
 
@@ -1242,4 +1243,16 @@ Trades multiple items between one actor to another, and currencies and/or change
 | buyer           | `Actor/Token/TokenDocument`                                                  |         | The actor that is buying the item                                                                                                                                                                                                                                                                                             |
 | items           | `Array<Object<{item: Item/string, quantity: number, paymentIndex: number}>>` |         | An array of objects containing the item or the id of the                                                                                              item to be sold, the quantity to be sold, and the payment                                                                                              index to be used |
 | [interactionId] | `string/boolean`                                                             | `false` | The ID of this interaction                                                                                                                                                                                                                                                                                                    |
+
+### getItemTypesThatCanStack
+
+`game.itempiles.API.getItemTypesThatCanStack()` ⇒ `Set<string>`
+
+Retrieve all system item types that can be stacked
+
+**Returns**: `Set<string>` - The items that were created and the attributes that were changed
+
+| Param           | Type                                                                         | Default | Description                                                                                                                                                                                                                                                                                                                   |
+|-----------------|------------------------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1250,7 +1250,7 @@ Trades multiple items between one actor to another, and currencies and/or change
 
 Retrieve all system item types that can be stacked
 
-**Returns**: `Set<string>` - The items that were created and the attributes that were changed
+**Returns**: `Set<string>` - The items type that can be stacked on this system
 
 | Param           | Type                                                                         | Default | Description                                                                                                                                                                                                                                                                                                                   |
 |-----------------|------------------------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/api.md
+++ b/docs/api.md
@@ -89,7 +89,6 @@
   * [rollItemTable](#rollItemTable)
   * [getPricesForItem](#getPricesForItem)
   * [tradeItems](#tradeItems)
-  * [getItemTypesThatCanStack](#getItemTypesThatCanStack)
 
 ## System settings methods
 
@@ -1331,15 +1330,5 @@ Trades multiple items between one actor to another, and currencies and/or change
 | items           | `Array<Object<{item: Item/string, quantity: number, paymentIndex: number}>>` |         | An array of objects containing the item or the id of the                                                                                              item to be sold, the quantity to be sold, and the payment                                                                                              index to be used |
 | [interactionId] | `string/boolean`                                                             | `false` | The ID of this interaction                                                                                                                                                                                                                                                                                                    |
 
-### getItemTypesThatCanStack
-
-`game.itempiles.API.getItemTypesThatCanStack()` ⇒ `Set<string>`
-
-Retrieve all system item types that can be stacked
-
-**Returns**: `Set<string>` - The items type that can be stacked on this system
-
-| Param           | Type                                                                         | Default | Description                                                                                                                                                                                                                                                                                                                   |
-|-----------------|------------------------------------------------------------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -889,6 +889,9 @@ game.itempiles.API.updateCurrencies(tokenOrActor, "10gp");
 // Set the value on the GP currency with the quantity 10 and on the SP currency with the quantity 5 to the target
 game.itempiles.API.updateCurrencies(tokenOrActor, "10gp 5sp");
 
+// Set the value on the GP currency with the quantity 1d4 and on the SP currency with the quantity 1d3 to the target
+game.itempiles.API.updateCurrencies(actor, "1d4gp 1d3sp")
+
 ```
 
 ---
@@ -918,7 +921,10 @@ const tokenOrActor = game.actors.getName("Bharash");
 game.itempiles.API.addCurrencies(tokenOrActor, "10gp");
 
 // Add 10 GP and 5 SP to the target
-game.itempiles.API.removeCurrencies(tokenOrActor, "10gp 5sp");
+game.itempiles.API.addCurrencies(tokenOrActor, "10gp 5sp");
+
+// Add 1d4 GP to the target
+game.itempiles.API.addCurrencies(tokenOrActor, "1d4gp");
 
 ```
 
@@ -951,6 +957,9 @@ game.itempiles.API.removeCurrencies(tokenOrActor, "10gp");
 
 // Remove 10 GP and 5 SP from the target
 game.itempiles.API.removeCurrencies(tokenOrActor, "10gp 5sp");
+
+// Remove 1d4 GP from the target
+game.itempiles.API.removeCurrencies(tokenOrActor, "1d4gp");
 
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -39,7 +39,13 @@
   * [rattleItemPile](#rattleItemPile)
   * [isItemPileLocked](#isItemPileLocked)
   * [isItemPileClosed](#isItemPileClosed)
+  * [isValidItemPile](#isValidItemPile)
+  * [isRegularItemPile](#isRegularItemPile)
   * [isItemPileContainer](#isItemPileContainer)
+  * [isItemPileLootable](#isItemPileLootable)
+  * [isItemPileVault](#isItemPileVault)
+  * [isItemPileMerchant](#isItemPileMerchant)
+  * [isItemPileAuctioneer](#isItemPileAuctioneer)
   * [updateItemPile](#updateItemPile)
   * [deleteItemPile](#deleteItemPile)
   * [splitItemPileContents](#splitItemPileContents)
@@ -516,9 +522,10 @@ Causes the item pile to play a sound as it was attempted to be opened, but was l
 
 Whether an item pile is locked. If it is not enabled or not a container, it is always false.
 
-| Param  | Type                  |
-|--------|-----------------------|
-| target | `Token/TokenDocument` |
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
 
 ---
 
@@ -528,9 +535,36 @@ Whether an item pile is locked. If it is not enabled or not a container, it is a
 
 Whether an item pile is closed. If it is not enabled or not a container, it is always false.
 
-| Param  | Type                  |
-|--------|-----------------------|
-| target | `Token/TokenDocument` |
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
+
+---
+
+### isValidItemPile
+
+`game.itempiles.API.isValidItemPile(target)` ⇒ `boolean`
+
+Whether an item pile is a valid item pile. If it is not enabled, it is always false.
+
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
+
+---
+
+### isRegularItemPile
+
+`game.itempiles.API.isRegularItemPile(target)` ⇒ `boolean`
+
+Whether an item pile is a regular item pile. If it is not enabled, it is always false.
+
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
 
 ---
 
@@ -540,9 +574,62 @@ Whether an item pile is closed. If it is not enabled or not a container, it is a
 
 Whether an item pile is a container. If it is not enabled, it is always false.
 
-| Param  | Type                  |
-|--------|-----------------------|
-| target | `Token/TokenDocument` |
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
+
+---
+
+### isItemPileLootable
+
+`game.itempiles.API.isItemPileLootable(target)` ⇒ `boolean`
+
+Whether an item pile is a lootable. If it is not enabled, it is always false.
+
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
+
+---
+
+### isItemPileVault
+
+`game.itempiles.API.isItemPileVault(target)` ⇒ `boolean`
+
+Whether an item pile is a vault. If it is not enabled, it is always false.
+
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
+
+---
+
+### isItemPileMerchant
+
+`game.itempiles.API.isItemPileMerchant(target)` ⇒ `boolean`
+
+Whether an item pile is a merchant. If it is not enabled, it is always false.
+
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
+
+---
+
+### isItemPileAuctioneer
+
+`game.itempiles.API.isItemPileAuctioneer(target)` ⇒ `boolean`
+
+Whether an item pile is a auctioneer. If it is not enabled, it is always false.
+
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+| [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,7 @@
   * [isItemPileVault](#isItemPileVault)
   * [isItemPileMerchant](#isItemPileMerchant)
   * [isItemPileAuctioneer](#isItemPileAuctioneer)
+  * [isItemPileEmpty](#isItemPileEmpty)
   * [updateItemPile](#updateItemPile)
   * [deleteItemPile](#deleteItemPile)
   * [splitItemPileContents](#splitItemPileContents)
@@ -631,6 +632,19 @@ Whether an item pile is a auctioneer. If it is not enabled, it is always false.
 | [data]             | `Object/boolean`              | `false` | Existing data flags to use    |
 
 ---
+
+### isItemPileEmpty
+
+`game.itempiles.API.isItemPileEmpty(target)` ⇒ `boolean`
+
+Whether an item pile is a empty pile. If it is not enabled, it is always false.
+
+| Param              | Type                          | Default | Description                   |
+|--------------------|-------------------------------|---------|-------------------------------|
+| target             | `Token/TokenDocument`         |         | Target token to check         |
+
+---
+
 
 ### updateItemPile
 

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -951,33 +951,114 @@ class API {
 	 * Whether an item pile is locked. If it is not enabled or not a container, it is always false.
 	 *
 	 * @param {Token/TokenDocument} target
-	 *
+	 * @param {Object/boolean} [data=false] data existing flags data to use
 	 * @return {boolean}
 	 */
-	static isItemPileLocked(target) {
-		return PileUtilities.isItemPileLocked(target);
+	static isItemPileLocked(target, data = false) {
+		return PileUtilities.isItemPileLocked(target, data);
 	}
 
 	/**
 	 * Whether an item pile is closed. If it is not enabled or not a container, it is always false.
 	 *
 	 * @param {Token/TokenDocument} target
-	 *
+	 * @param {Object/boolean} [data=false] data existing flags data to use
 	 * @return {boolean}
 	 */
-	static isItemPileClosed(target) {
-		return PileUtilities.isItemPileClosed(target);
+	static isItemPileClosed(target, data = false) {
+		return PileUtilities.isItemPileClosed(target, data);
 	}
 
+	/**
+	 * Whether an item pile is a valid item pile. If it is not enabled, it is always false.
+	 *
+	 * @param {Token/TokenDocument} target
+	 * @param {Object/boolean} [data=false] data existing flags data to use
+	 * @return {boolean}
+	 */
+	static isValidItemPile(target, data = false) {
+		return PileUtilities.isValidItemPile(target, data);
+	}
+	
+    /**
+	 * Whether an item pile is a regular item pile. If it is not enabled, it is always false.
+	 *
+	 * @param {Token/TokenDocument} target
+	 * @param {Object/boolean} [data=false] data existing flags data to use
+	 * @return {boolean}
+	 */
+	static isRegularItemPile(target, data = false) {
+		return PileUtilities.isRegularItemPile(target, data);
+	}
+	
 	/**
 	 * Whether an item pile is a container. If it is not enabled, it is always false.
 	 *
 	 * @param {Token/TokenDocument} target
-	 *
+	 * @param {Object/boolean} [data=false] data existing flags data to use
 	 * @return {boolean}
 	 */
-	static isItemPileContainer(target) {
-		return PileUtilities.isItemPileContainer(target);
+	static isItemPileContainer(target, data = false) {
+		return PileUtilities.isItemPileContainer(target, data);
+	}
+	
+	/**
+	 * Whether an item pile is a lootable. If it is not enabled, it is always false.
+	 *
+	 * @param {Token/TokenDocument} target
+	 * @param {Object/boolean} [data=false] data existing flags data to use
+	 * @return {boolean}
+	 */
+	static isItemPileLootable(target, data = false) {
+		return PileUtilities.isItemPileLootable(target, data);
+	}
+	
+	/**
+	 * Whether an item pile is a vault. If it is not enabled, it is always false.
+	 *
+	 * @param {Token/TokenDocument} target
+	 * @param {Object/boolean} [data=false] data existing flags data to use
+	 * @return {boolean}
+	 */
+	static isItemPileVault(target, data = false) {
+		return PileUtilities.isItemPileVault(target, data);
+	}
+	
+	/**
+	 * Whether an item pile is a merchant. If it is not enabled, it is always false.
+	 *
+	 * @param {Token/TokenDocument} target
+	 * @param {Object/boolean} [data=false] data existing flags data to use
+	 * @return {boolean}
+	 */
+	static isItemPileMerchant(target, data = false) {
+		return PileUtilities.isItemPileMerchant(target, data);
+	}
+	
+	/**
+	 * Whether an item pile is a merchant. If it is not enabled, it is always false.
+	 *
+	 * @param {Token/TokenDocument} target
+	 * @param {Object/boolean} [data=false] data existing flags data to use
+	 * @return {boolean}
+	 */
+	static isItemPileAuctioneer(target, data = false) {
+		return PileUtilities.isItemPileAuctioneer(target, data);
+	}
+
+	static isItemPileEmpty(target) {
+	
+		const targetActor = Utilities.getActor(target);
+		if (!targetActor) return false;
+	
+		const validItemPile = isValidItemPile(targetActor);
+		if (!validItemPile) return false;
+	
+		const hasNoItems = getActorItems(targetActor).length === 0;
+		const hasNoAttributes = getActorCurrencies(targetActor).length === 0;
+	
+		return validItemPile && hasNoItems && hasNoAttributes;
+	
 	}
 
 	/**

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -2476,7 +2476,7 @@ class API {
 
 	/**
 	 * Retrieve all system item types that can be stacked
-	 * @returns {Set<string>}                       The items that can be stacked on this system
+	 * @returns {Set<string>}                       The items type that can be stacked on this system
 	 */
 	static getItemTypesThatCanStack() {
 		return Utilities.getItemTypesThatCanStack();

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -1047,7 +1047,7 @@ class API {
 	}
 
 	/**
-	 * Whether an item pile is empty. If it is not enabled, it is always false.
+	 * Whether an item pile is empty pile. If it is not enabled, it is always false.
 	 *
 	 * @param {Token/TokenDocument} target
 	 * @return {boolean}

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -1046,19 +1046,14 @@ class API {
 		return PileUtilities.isItemPileAuctioneer(target, data);
 	}
 
+	/**
+	 * Whether an item pile is empty. If it is not enabled, it is always false.
+	 *
+	 * @param {Token/TokenDocument} target
+	 * @return {boolean}
+	 */
 	static isItemPileEmpty(target) {
-	
-		const targetActor = Utilities.getActor(target);
-		if (!targetActor) return false;
-	
-		const validItemPile = isValidItemPile(targetActor);
-		if (!validItemPile) return false;
-	
-		const hasNoItems = getActorItems(targetActor).length === 0;
-		const hasNoAttributes = getActorCurrencies(targetActor).length === 0;
-	
-		return validItemPile && hasNoItems && hasNoAttributes;
-	
+		return PileUtilities.isItemPileEmpty(target);
 	}
 
 	/**
@@ -2553,14 +2548,6 @@ class API {
 
 		return ItemPileSocket.executeAsGM(ItemPileSocket.HANDLERS.TRADE_ITEMS, sellerUuid, buyerUuid, itemsToSell, game.user.id, { interactionId });
 
-	}
-
-	/**
-	 * Retrieve all system item types that can be stacked
-	 * @returns {Set<string>}                       The items type that can be stacked on this system
-	 */
-	static getItemTypesThatCanStack() {
-		return Utilities.getItemTypesThatCanStack();
 	}
 
 	static canItemFitInVault(item, vaultActor) {

--- a/src/API/api.js
+++ b/src/API/api.js
@@ -2474,6 +2474,14 @@ class API {
 
 	}
 
+	/**
+	 * Retrieve all system item types that can be stacked
+	 * @returns {Set<string>}                       The items that can be stacked on this system
+	 */
+	static getItemTypesThatCanStack() {
+		return Utilities.getItemTypesThatCanStack();
+	}
+
 	static canItemFitInVault(item, vaultActor) {
 		return PileUtilities.canItemFitInVault(item, vaultActor);
 	}

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -75,7 +75,8 @@ const CONSTANTS = {
 		PILE: "pile",
 		CONTAINER: "container",
 		MERCHANT: "merchant",
-		VAULT: "vault"
+		VAULT: "vault",
+		AUCTIONEER: "auctioneer",
 	},
 
 	VAULT_LOGGING_TYPES: {

--- a/src/helpers/pile-utilities.js
+++ b/src/helpers/pile-utilities.js
@@ -129,6 +129,12 @@ export function isItemPileMerchant(target, data = false) {
 	return pileData?.enabled && pileData?.type === CONSTANTS.PILE_TYPES.MERCHANT;
 }
 
+export function isItemPileAuctioneer(target, data = false) {
+	const targetActor = Utilities.getActor(target);
+	const pileData = getActorFlagData(targetActor, data);
+	return pileData?.enabled && pileData?.type === CONSTANTS.PILE_TYPES.AUCTIONEER;
+}
+
 export function isItemPileClosed(target, data = false) {
 	const targetActor = Utilities.getActor(target);
 	const pileData = getActorFlagData(targetActor, data);

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -132,6 +132,10 @@ export function refreshItemTypesThatCanStack() {
 	getItemTypesThatCanStack();
 }
 
+/**
+ * Retrieve all system item types that can be stacked
+ * @returns {Set<string>}                       The items that can be stacked on this system
+ */
 export function getItemTypesThatCanStack() {
 	if (!itemTypesWithQuantities) {
 

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -134,7 +134,7 @@ export function refreshItemTypesThatCanStack() {
 
 /**
  * Retrieve all system item types that can be stacked
- * @returns {Set<string>}                       The items that can be stacked on this system
+ * @returns {Set<string>}                       The items type that can be stacked on this system
  */
 export function getItemTypesThatCanStack() {
 	if (!itemTypesWithQuantities) {


### PR DESCRIPTION
I only needed the `isMerchant` but while I was at it I did it for all types including the `Auctioneer` ? I think it is useful for other modules that want to integrate their own controls ?