### PR TITLE
handle result from merchant columns as an array

### DIFF
--- a/src/applications/item-pile-config/settings/merchant.svelte
+++ b/src/applications/item-pile-config/settings/merchant.svelte
@@ -80,7 +80,7 @@
 			{ id: `merchant-columns-item-pile-config-${pileActor.id}` },
 			{ title: localize("ITEM-PILES.Applications.MerchantColumnsEditor.TitleActor", { actor_name: pileActor.name }), }
 		).then((result) => {
-			pileData.merchantColumns = Array.isArray(result.merchantColumns) ? result.merchantColumns : [];
+			pileData.merchantColumns = Array.isArray(result) ? result : [];
 		});
 	}
 


### PR DESCRIPTION
The object `result` when saving merchant columns is an array, however the object `result.merchantColumns` doesn't exist. This should fix it.

Tested with directly modifying `module.js` on a live instance and transposed the result to the source code.

fix #568