### PR TITLE
update pf1 support

### DIFF
--- a/src/systems/_index.js
+++ b/src/systems/_index.js
@@ -4,6 +4,7 @@ import dnd4e0443 from "./dnd4e-0.4.43.js";
 import dnd5e from "./dnd5e.js";
 import dnd5e203 from "./dnd5e-2.0.3.js";
 import pf1 from "./pf1.js";
+import pf1_9 from "./pf1-9.0.js";
 import pf2e from "./pf2e.js";
 import ds4 from "./ds4.js";
 import d35e from "./d35e.js";
@@ -61,7 +62,8 @@ export default {
 		"2.0.3": dnd5e203,
 	},
 	"pf1": {
-		"latest": pf1
+		"latest": pf1,
+		"9.6": pf1_9
 	},
 	"pf2e": {
 		"latest": pf2e

--- a/src/systems/pf1-9.0.js
+++ b/src/systems/pf1-9.0.js
@@ -1,0 +1,97 @@
+// PF1 v9.0–9.6
+export default {
+
+	"VERSION": "1.0.5",
+
+	// The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
+	"ACTOR_CLASS_TYPE": "npc",
+
+	// The item class type is the type of item that will be used for the default loot item
+	"ITEM_CLASS_LOOT_TYPE": "equipment",
+
+	// The item class type is the type of item that will be used for the default weapon item
+	"ITEM_CLASS_WEAPON_TYPE": "", 
+
+	// The item class type is the type of item that will be used for the default equipment item
+	"ITEM_CLASS_EQUIPMENT_TYPE": "",
+
+	// The item quantity attribute is the path to the attribute on items that denote how many of that item that exists
+	"ITEM_QUANTITY_ATTRIBUTE": "system.quantity",
+
+	// The item price attribute is the path to the attribute on each item that determine how much it costs
+	"ITEM_PRICE_ATTRIBUTE": "system.price",
+
+	// This function is an optional system handler that specifically transforms an item's price into a more unified numeric format
+	"ITEM_COST_TRANSFORMER": (item, currencies) => {
+		// Account for wand charges, broken condition, and other traits that are not reflected in base price.
+		// Spoof quantity to 1 temporarily
+		const origQuantity = item.system.quantity;
+		item.system.quantity = 1;
+		// Get actual value
+		const value = item.getValue({ sellValue: 1.0 });
+		// Restore quantity
+		item.system.quantity = origQuantity;
+		return value;
+	},
+
+	// Item types and the filters actively remove items from the item pile inventory UI that users cannot loot, such as spells, feats, and classes
+	"ITEM_FILTERS": [
+		{
+			"path": "type",
+			"filters": "attack,buff,class,feat,race,spell"
+		}
+	],
+
+	// Item similarities determines how item piles detect similarities and differences in the system
+	"ITEM_SIMILARITIES": ["name", "type"],
+
+	// Currencies in item piles is a versatile system that can accept actor attributes (a number field on the actor's sheet) or items (actual items in their inventory)
+	// In the case of attributes, the path is relative to the "actor.system"
+	// In the case of items, it is recommended you export the item with `.toObject()` and strip out any module data
+	"CURRENCIES": [
+		{
+			type: "attribute",
+			name: "PF1.CurrencyPlatinumP",
+			img: "systems/pf1/icons/items/inventory/coins-silver.jpg",
+			abbreviation: "{#}P",
+			data: {
+				path: "system.currency.pp",
+			},
+			primary: false,
+			exchangeRate: 10
+		},
+		{
+			type: "attribute",
+			name: "PF1.CurrencyGoldP",
+			img: "systems/pf1/icons/items/inventory/coin-gold.jpg",
+			abbreviation: "{#}G",
+			data: {
+				path: "system.currency.gp",
+			},
+			primary: true,
+			exchangeRate: 1
+		},
+		{
+			type: "attribute",
+			name: "PF1.CurrencySilverP",
+			img: "systems/pf1/icons/items/inventory/coin-silver.jpg",
+			abbreviation: "{#}S",
+			data: {
+				path: "system.currency.sp",
+			},
+			primary: false,
+			exchangeRate: 0.1
+		},
+		{
+			type: "attribute",
+			name: "PF1.CurrencyCopperP",
+			img: "systems/pf1/icons/items/inventory/coin-copper.jpg",
+			abbreviation: "{#}C",
+			data: {
+				path: "system.currency.cp",
+			},
+			primary: false,
+			exchangeRate: 0.01
+		}
+	]
+};

--- a/src/systems/pf1.js
+++ b/src/systems/pf1.js
@@ -1,18 +1,18 @@
 export default {
 
-	"VERSION": "1.0.5",
+	"VERSION": "1.1.0",
 
 	// The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
 	"ACTOR_CLASS_TYPE": "npc",
 
 	// The item class type is the type of item that will be used for the default loot item
-	"ITEM_CLASS_LOOT_TYPE": "equipment",
+	"ITEM_CLASS_LOOT_TYPE": "loot",
 
 	// The item class type is the type of item that will be used for the default weapon item
-	"ITEM_CLASS_WEAPON_TYPE": "", 
+	"ITEM_CLASS_WEAPON_TYPE": "weapon", 
 
 	// The item class type is the type of item that will be used for the default equipment item
-	"ITEM_CLASS_EQUIPMENT_TYPE": "",
+	"ITEM_CLASS_EQUIPMENT_TYPE": "equipment",
 
 	// The item quantity attribute is the path to the attribute on items that denote how many of that item that exists
 	"ITEM_QUANTITY_ATTRIBUTE": "system.quantity",
@@ -23,14 +23,7 @@ export default {
 	// This function is an optional system handler that specifically transforms an item's price into a more unified numeric format
 	"ITEM_COST_TRANSFORMER": (item, currencies) => {
 		// Account for wand charges, broken condition, and other traits that are not reflected in base price.
-		// Spoof quantity to 1 temporarily
-		const origQuantity = item.system.quantity;
-		item.system.quantity = 1;
-		// Get actual value
-		const value = item.getValue({ sellValue: 1.0 });
-		// Restore quantity
-		item.system.quantity = origQuantity;
-		return value;
+		return item.getValue({ sellValue: 1.0, single: true });
 	},
 
 	// Item types and the filters actively remove items from the item pile inventory UI that users cannot loot, such as spells, feats, and classes
@@ -41,8 +34,11 @@ export default {
 		}
 	],
 
+	
+	"UNSTACKABLE_ITEM_TYPES": ["container"],
+
 	// Item similarities determines how item piles detect similarities and differences in the system
-	"ITEM_SIMILARITIES": ["name", "type"],
+	"ITEM_SIMILARITIES": ["name", "type", "system.subType", "system.masterwork", "system.enh", "system.armor.enh"],
 
 	// Currencies in item piles is a versatile system that can accept actor attributes (a number field on the actor's sheet) or items (actual items in their inventory)
 	// In the case of attributes, the path is relative to the "actor.system"
@@ -50,7 +46,7 @@ export default {
 	"CURRENCIES": [
 		{
 			type: "attribute",
-			name: "PF1.CurrencyPlatinumP",
+			name: "PF1.Currency.Full.pp",
 			img: "systems/pf1/icons/items/inventory/coins-silver.jpg",
 			abbreviation: "{#}P",
 			data: {
@@ -61,7 +57,7 @@ export default {
 		},
 		{
 			type: "attribute",
-			name: "PF1.CurrencyGoldP",
+			name: "PF1.Currency.Full.gp",
 			img: "systems/pf1/icons/items/inventory/coin-gold.jpg",
 			abbreviation: "{#}G",
 			data: {
@@ -72,7 +68,7 @@ export default {
 		},
 		{
 			type: "attribute",
-			name: "PF1.CurrencySilverP",
+			name: "PF1.Currency.Full.sp",
 			img: "systems/pf1/icons/items/inventory/coin-silver.jpg",
 			abbreviation: "{#}S",
 			data: {
@@ -83,7 +79,7 @@ export default {
 		},
 		{
 			type: "attribute",
-			name: "PF1.CurrencyCopperP",
+			name: "PF1.Currency.Full.cp",
 			img: "systems/pf1/icons/items/inventory/coin-copper.jpg",
 			abbreviation: "{#}C",
 			data: {


### PR DESCRIPTION
Changes:
- Alters cost transformer to be more sane
  - This increases minimum PF1 version to v10.0
    - Added old config for v9.x
- Adds more similarity data points
- Disallows stacking containers which don't support it
- Fixes invalid item type configuration
- Updates i18n keys

Fixes #643