### PR TITLE
Enhanced Alien RPG system support (Evolved)

### DIFF
--- a/systems/alienrpg.js
+++ b/systems/alienrpg.js
@@ -1,5 +1,34 @@
 export default {
-	"VERSION": "1.0.1",
+	"VERSION": "1.0.2",
+
+	// The actor class type is the type of actor that will be used for the default item pile actor that is created on first item drop.
+	"ACTOR_CLASS_TYPE": "character",
+
+	// The item class type is the type of item that will be used for the default loot item
+	"ITEM_CLASS_LOOT_TYPE": "item",
+
+	// The item class type is the type of item that will be used for the default weapon item
+	"ITEM_CLASS_WEAPON_TYPE": "weapon",
+
+	// The item class type is the type of item that will be used for the default equipment item
+	"ITEM_CLASS_EQUIPMENT_TYPE": "armor",
+
+	// The item quantity attribute is the path to the attribute on items that denote how many of that item that exists
+	"ITEM_QUANTITY_ATTRIBUTE": "system.attributes.quantity.value",
+
+	// The item price attribute is the path to the attribute on each item that determine how much it costs
+	"ITEM_PRICE_ATTRIBUTE": "system.attributes.cost.value",
+
+	// Item types and the filters actively remove items from the item pile inventory UI that users cannot loot, such as spells, feats, and classes
+	"ITEM_FILTERS": [{
+		"path": "type",
+		"filters": "talent,planet-system,skill-stunts,agenda,specialty,critical-injury,spacecraftweapons,spacecraftmods,spacecraft-crit,colony-initiative"
+	}],
+
+	// Item similarities determines how item piles detect similarities and differences in the system
+	"ITEM_SIMILARITIES": ["name", "type"],
+
+	// Currencies in item piles - Alien RPG uses a cash attribute on character/synthetic actors
 	"CURRENCIES": [
 		{
 			"type": "attribute",
@@ -13,30 +42,16 @@ export default {
 			"exchangeRate": 1
 		}
 	],
+
+	// Currency can have decimal values (e.g., $1.50)
 	"CURRENCY_DECIMAL_DIGITS": 0.01,
-	"ITEM_FILTERS": [{
-		"path": "type",
-		"filters": "talent,planet-system,skill-stunts,agenda,specialty,critical-injury"
-	}],
+
+	// This function transforms item prices from strings (e.g., "$100" or "100,000") into numeric format
 	"ITEM_COST_TRANSFORMER": (item) => {
 		let overallCost = foundry.utils.getProperty(item, "system.attributes.cost.value");
 		if (overallCost) {
 			overallCost = overallCost.replace("$", "").replace(",", "");
 		}
 		return Number(overallCost) ?? 0;
-	},
-	"ITEM_SIMILARITIES": ["name", "type"],
-	"ACTOR_CLASS_TYPE": "character",
-
-	// The item class type is the type of item that will be used for the default loot item
-	"ITEM_CLASS_LOOT_TYPE": "",
-
-	// The item class type is the type of item that will be used for the default weapon item
-	"ITEM_CLASS_WEAPON_TYPE": "", 
-
-	// The item class type is the type of item that will be used for the default equipment item
-	"ITEM_CLASS_EQUIPMENT_TYPE": "",
-
-	"ITEM_QUANTITY_ATTRIBUTE": "system.attributes.quantity.value",
-	"ITEM_PRICE_ATTRIBUTE": "system.attributes.cost.value"
+	}
 }


### PR DESCRIPTION
## Enhanced Alien RPG System Support

  ### Changes
  This PR completes the Alien RPG system configuration by adding missing item type definitions and filters:

  - **Item class types**: Added loot (`item`), weapon (`weapon`), and equipment (`armor`) types for proper item pile categorization
  - **Item filters**: Expanded to exclude non-lootable items including spacecraft weapons/mods, spacecraft crits, and colony initiatives
  - **Documentation**: Added comments throughout for better maintainability
  - **Version**: Bumped from 1.0.1 to 1.0.2

  ### Configuration Summary
  - Uses attribute-based currency at `system.general.cash.value`
  - Supports decimal currency values (e.g., $1.50)
  - Handles string-based item costs with automatic parsing (e.g., "$100", "100,000")
  - Item quantity path: `system.attributes.quantity.value`
  - Item price path: `system.attributes.cost.value`

  ### Testing
  Tested with Alien RPG system (alienrpg) to ensure proper item pile functionality with the updated configuration.

  ### Breaking Changes
  None - this is backward compatible enhancement to existing support.