### PR TITLE
Add Foundry VTT v14 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,8 +6,8 @@
   "library": "false",
   "compatibility": {
     "minimum": "12",
-    "verified": "13",
-    "maximum": "13"
+    "verified": "14",
+    "maximum": "14"
   },
   "authors": [
     {

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -8,6 +8,7 @@ const CONSTANTS = {
 	MODULE_NAME: module_name,
 	PATH: module_path,
 	IS_V13: false,
+	IS_V14: false,
 
 	ACTOR_DELTA_PROPERTY: "delta",
 

--- a/src/foundry-ui-overrides.js
+++ b/src/foundry-ui-overrides.js
@@ -53,7 +53,7 @@ function hideTemporaryItems(sidebar) {
 
 function createTradeButton() {
 	const minimalUI = game.modules.get('minimal-ui')?.active;
-	const classes = "item-piles-player-list-trade-button" + (minimalUI ? " item-piles-minimal-ui" : "") + (CONSTANTS.IS_V13 ? " item-piles-v13" : "");
+	const classes = "item-piles-player-list-trade-button" + (minimalUI ? " item-piles-minimal-ui" : "") + ((CONSTANTS.IS_V13 || CONSTANTS.IS_V14) ? " item-piles-v13" : "");
 	const text = !minimalUI ? game.i18n.localize("ITEM-PILES.ContextMenu.RequestTrade") : "";
 	const button = $(`<button type="button" class="${classes}"><i class="fas fa-handshake"></i>${text}</button>`)
 	button.click(() => {
@@ -187,8 +187,8 @@ function renderPileHUD(app, html) {
 
 	const pileData = PileUtilities.getActorFlagData(document);
 
-	const htmlType = CONSTANTS.IS_V13 ? "button" : "div";
-	const offset = CONSTANTS.IS_V13 ? "85" : "130";
+	const htmlType = (CONSTANTS.IS_V13 || CONSTANTS.IS_V14) ? "button" : "div";
+	const offset = (CONSTANTS.IS_V13 || CONSTANTS.IS_V14) ? "85" : "130";
 
 	const container = $(`<div class="col right" style="right:-${offset}px;"></div>`);
 

--- a/src/foundry-ui-overrides.js
+++ b/src/foundry-ui-overrides.js
@@ -294,7 +294,8 @@ class FastTooltipManager extends (foundry?.helpers?.interaction?.TooltipManager?
 	 * @param {PointerEvent} event    The initiating pointerenter event
 	 */
 	#onActivate(event) {
-		if (Tour.tourInProgress) return; // Don't activate tooltips during a tour
+		const TourCls = foundry?.nue?.Tour ?? Tour;
+		if (TourCls.tourInProgress) return; // Don't activate tooltips during a tour
 		const element = event.target;
 		if (!element.dataset.fastTooltip) {
 			// Check if the element has moved out from underneath the cursor and pointerenter has fired on a non-child of the

--- a/src/module.js
+++ b/src/module.js
@@ -26,6 +26,7 @@ import { TJSPosition } from "#runtime/svelte/store/position";
 
 Hooks.once("init", async () => {
 	CONSTANTS.IS_V13 = foundry.utils.isNewerVersion(game.version, 13);
+	CONSTANTS.IS_V14 = foundry.utils.isNewerVersion(game.version, 14);
 	Object.freeze(CONSTANTS);
 
 	//CONFIG.debug.hooks = true;
@@ -53,7 +54,7 @@ Hooks.once("init", async () => {
 
 	window.ItemPiles = Helpers.deprecate({ API }, "API", "window.ItemPiles.API has been deprecated, please use game.itempiles.API instead")
 
-	if (CONSTANTS.IS_V13) {
+	if (CONSTANTS.IS_V13 || CONSTANTS.IS_V14) {
 		window.MIN_WINDOW_WIDTH = 200;
 		window.MIN_WINDOW_HEIGHT = 50;
 		Object.defineProperty(SvelteApplication, 'defaultOptions', {


### PR DESCRIPTION
## Summary
Minimal patch to restore Item Piles compatibility with Foundry VTT v14.

Addresses #815.

## Changes
- `module.json`: bump `compatibility.verified` and `compatibility.maximum` to `14` (minimum unchanged at `12`)
- `src/constants/constants.js`: add `IS_V14` constant alongside existing `IS_V13`
- `src/module.js`: initialize `IS_V14 = foundry.utils.isNewerVersion(game.version, 14)`; gate the `SvelteApplication.defaultOptions` override on `IS_V13 || IS_V14`
- `src/foundry-ui-overrides.js`: extend the two `IS_V13 ? ... : ...` branches (trade button class, token HUD `htmlType`/`offset`) to also cover v14; replace deprecated global `Tour` with `foundry?.nue?.Tour ?? Tour` inside `FastTooltipManager#onActivate` to silence the v13 deprecation warning (removed in v15)

Most of the patch is attribution to [`cadywdnddm-web/FoundryVTT-ItemPiles`](https://github.com/cadywdnddm-web/FoundryVTT-ItemPiles); I rebased it on current `master`, added the `Tour` namespace fix, and kept the upstream version and URLs intact so you can cut the release however you prefer.

## Known v14 risks not addressed here
These did not surface in smoke-testing against dnd5e 5.3.0, but are worth auditing before cutting a stable release:
- v14 `ActiveEffect` schema migration (`mode` int → `type` string; `changes` moved under `system.changes`) — item-piles hooks on effects for currency items
- `DataModel.updateSource` `-=` / `==` operator deprecation in favor of `DataFieldOperator`
- `renderChatMessage` hook deprecation (fires in chat-api paths)

## Test plan
- [x] Module loads in Foundry v14.359 with dnd5e 5.3.0 (no v13/14 deprecation noise from item-piles code)
- [x] Still loads in Foundry v13 (branches are additive — `IS_V13 || IS_V14` preserves v13 behavior)
- [ ] Full functional pass (drop pile, loot, merchant, vault, trade) — not yet exercised, maintainer's smoke-test is advised