### PR TITLE
Bump compatibility to v14 and fix bare getProperty in token migration

### DIFF
--- a/module.json
+++ b/module.json
@@ -6,8 +6,8 @@
   "library": "false",
   "compatibility": {
     "minimum": "12",
-    "verified": "13",
-    "maximum": "13"
+    "verified": "14",
+    "maximum": "14"
   },
   "authors": [
     {

--- a/src/migrations.js
+++ b/src/migrations.js
@@ -85,7 +85,7 @@ async function updateTokens(version, callback) {
 		const scene = game.scenes.get(sceneId)
 		const updates = tokens.map(token => ({
 			_id: token.id,
-			[CONSTANTS.FLAGS.PILE]: callback(getProperty(token, CONSTANTS.FLAGS.PILE)),
+			[CONSTANTS.FLAGS.PILE]: callback(foundry.utils.getProperty(token, CONSTANTS.FLAGS.PILE)),
 			[CONSTANTS.FLAGS.VERSION]: version,
 		}));
 		if (updates.length) {


### PR DESCRIPTION
## What

- `module.json`: bump `compatibility.verified` and `compatibility.maximum` from `13` to `14`.
- `src/migrations.js` (`updateTokens`): replace the bare global `getProperty(token, CONSTANTS.FLAGS.PILE)` with `foundry.utils.getProperty(...)`.

## Why

Foundry v14 (14.360 stable) no longer ships a `globalThis.getProperty` shim. The non-namespaced helpers (`getProperty`, `setProperty`, `mergeObject`, `duplicate`, …) were never re-added to the v13/v14 backwards-compatibility map (see `client/client.mjs` `addBackwardsCompatibilityReferences` — it only aliases class names like `Compendium`, `Application`, `renderTemplate`, etc., not utility functions). On a world that still has Item Pile tokens flagged with an older module version, the init-time migration in `updateTokens` calls `getProperty(token, ...)` and throws `ReferenceError: getProperty is not defined`, aborting the migration for that scene. This is the only remaining bare global utility call I could find in `src/`.

The rest of the bundle is already v14-clean: the existing `IS_V13` runtime branches in `module-overrides.js` cover the renamed sidebar `_onClickEntry` and the namespaced `foundry.applications.ux.DragDrop` paths, and the deprecated globals it still references (`Application`, `FormApplication`, `Compendium`, `renderTemplate`, the `renderChatMessage` hook) are all still resolved by v14's compatibility shims (deprecated until v15/v16, no breakage).

## Tested

- FVTT 14.360 stable + PF2e 8.1.1, with `lib-wrapper` 1.13.5.1 and `socketlib` 1.1.4 active.
- Loot pile drop / loot / merchant flows all open and transact.
- Migration path verified by loading a world that previously had v3.1.x flagged piles — no more `ReferenceError` during init.
