### PR TITLE
[v14 BugFix] Fix Broken ChatMessages

### DIFF
--- a/src/API/chat-api.js
+++ b/src/API/chat-api.js
@@ -291,7 +291,7 @@ export default class ChatAPI {
 
 		return this._createNewChatMessage(userId, {
 			user: game.user.id,
-			type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			content: chatCardHtml,
 			flavor: "Item Piles",
 			speaker: ChatMessage.getSpeaker({ alias: game.user.name }),
@@ -370,7 +370,7 @@ export default class ChatAPI {
 
 		return this._createNewChatMessage(userId, {
 			user: game.user.id,
-			type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			content: chatCardHtml,
 			flavor: "Item Piles",
 			speaker: ChatMessage.getSpeaker({ alias: game.user.name })
@@ -392,7 +392,7 @@ export default class ChatAPI {
 
 		return this._createNewChatMessage(game.user.id, {
 			user: game.user.id,
-			type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			content: chatCardHtml,
 			flavor: "Item Piles",
 			speaker: ChatMessage.getSpeaker({ alias: game.user.name }),
@@ -435,7 +435,7 @@ export default class ChatAPI {
 
 		return this._createNewChatMessage(game.user.id, {
 			user: game.user.id,
-			type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			content: chatCardHtml,
 			flavor: "Item Piles" + (isPrivate ? ": " + game.i18n.localize("ITEM-PILES.Chat.PrivateTrade") : ""),
 			speaker: ChatMessage.getSpeaker({ alias: game.user.name }),
@@ -481,7 +481,7 @@ export default class ChatAPI {
 
 		return this._createNewChatMessage(userId, {
 			user: game.user.id,
-			type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			content: chatCardHtml,
 			flavor: "Item Piles",
 			speaker: ChatMessage.getSpeaker({ alias: game.user.name }),
@@ -527,7 +527,7 @@ export default class ChatAPI {
 
 		const chatData = {
 			user: user.id,
-			type: CONST.CHAT_MESSAGE_STYLES.OTHER,
+			style: CONST.CHAT_MESSAGE_STYLES.OTHER,
 			content: chatCardHtml,
 			flavor: "Item Piles",
 			speaker: ChatMessage.getSpeaker({ alias: user.name }),


### PR DESCRIPTION
`ChatMessage.type` was deprecated in v12, and as of v14 is now fully unsupported. (See https://github.com/foundryvtt/foundryvtt/issues/10185)

I replaced the references to type with `ChatMessage.style` which seems to be the proper code path now.

-----

Reason for Fix: Was testing itempiles-pf2e on v14, and any time Item Piles tried to post a message to chat, it would throw an error and fail. For example, when a player clicks the take button on an item pile to take an item from the pile.