### PR TITLE
wall-height module support & updated 3d distance calculation

### DIFF
--- a/src/API/private-api.js
+++ b/src/API/private-api.js
@@ -1939,7 +1939,7 @@ export default class PrivateAPI {
 
 				if (sourceToken) {
 
-					const distance = Math.floor(Utilities.distance_between_rect(sourceToken, dropData.target.object) / canvas.grid.size) + 1
+					const distance = Utilities.grids_between_tokens(sourceToken, dropData.target.object)
 
 					const pileData = PileUtilities.getActorFlagData(dropData.target);
 

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -337,8 +337,52 @@ export function distance_between(a, b) {
 	return new Ray(a, b).distance;
 }
 
+function getTokenElevation(tokenLike) {
+	const doc = tokenLike?.document ?? tokenLike;
+	const elevation = doc?.elevation ?? tokenLike?.elevation ?? 0;
+	return Number.isFinite(elevation) ? elevation : 0;
+}
+
+function getTokenHeight(tokenLike) {
+	const doc = tokenLike?.document ?? tokenLike;
+	const gridDistance = canvas.scene?.grid?.distance ?? 5;
+
+	//if wall height module is enabled, get token height. Else return whatever the grid distance is or 5. 
+	//opportunity to implement something for levels v14 in the future here as a fallback for when wall-height is not enabled.
+	const height = Number(
+		doc?.flags?.["wall-height"]?.tokenHeight
+	);
+
+	//
+	if (Number.isFinite(height) && height > 0) {
+		return height;
+	}
+
+	return gridDistance;
+}
+
+function getVerticalGapFromSourceToTarget(sourceToken, targetToken) {
+	const sourceBottom = getTokenElevation(sourceToken);
+	const sourceTop = sourceBottom + getTokenHeight(sourceToken);
+
+	const targetBottom = getTokenElevation(targetToken);
+	const targetTop = targetBottom + getTokenHeight(targetToken);
+
+	if (targetBottom > sourceTop) return targetBottom - sourceTop;
+	if (targetTop < sourceBottom) return sourceBottom - targetTop;
+
+	return 0;
+}
+
 export function grids_between_tokens(a, b) {
-	return Math.floor(distance_between_rect(a, b) / canvas.grid.size) + 1
+	const xyDistancePixels = distance_between_rect(a, b);
+	const xyDistanceGrids = xyDistancePixels / canvas.grid.size;
+
+	const gridDistance = canvas.scene?.grid?.distance || 5;
+	const verticalGap = getVerticalGapFromSourceToTarget(a, b);
+	const zDistanceGrids = verticalGap / gridDistance;
+
+	return Math.floor(Math.hypot(xyDistanceGrids, zDistanceGrids)) + 1;
 }
 
 export function tokens_close_enough(a, b, maxDistance) {


### PR DESCRIPTION
- Checks for the wall-height module, and if not enabled, source token height is assumed to be equal to grid distance (e.g. 5).
- Includes the vertical gap from source to target as a component of a 3d distance calculation. Vertical gap takes into account the source's "height". This allows for taller source tokens reaching elevation target tokens. 

See supporting data structure from wall-height module below:

<img width="1419" height="666" alt="image" src="https://github.com/user-attachments/assets/c356886b-c5fd-4fdd-89b3-f1f559e64ec6" />
