### PR TITLE
Add Item Price Modifiers editor & support

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -574,10 +574,18 @@
         "ItemType": "Item Type",
         "Override": "Override"
       },
+      "ItemPriceModifiersEditor": {
+        "Title": "Item Price Modifiers Editor",
+        "TitleActor": "Item Price Modifiers Editor: {actor_name}",
+        "Explanation": "Here you can define the price and sell price modifiers for this merchant relating to specific items. The \"Override\" setting means that it overrides the merchant's normal price modifiers, including item-type specific price modifiers.",
+        "DragDrop": "Drag and drop an item to add it to the list",
+        "Item": "Item",
+        "Override": "Override"
+      },
       "PriceModifiersEditor": {
         "Title": "Item Piles Price Modifiers Editor",
         "TitleActor": "Item Piles Price Modifiers Editor: {actor_name}",
-        "Explanation": "Here you can define the price and sell price modifiers for this merchant relating to specific actors. The \"Override\" setting means that it overrides the merchant's normal price modifiers, including item-type specific price modifiers.",
+        "Explanation": "Here you can define the price and sell price modifiers for this merchant relating to specific actors. The \"Override\" setting means that it overrides the merchant's normal price modifiers, including item-type and item specific price modifiers.",
         "DragDrop": "Drag and drop an actor to add it to the list",
         "Actor": "Actor",
         "Override": "Override"
@@ -717,12 +725,15 @@
           "RefreshItemsHolidays": "Refresh Items Holidays (Simple Calendar)",
           "RefreshItemsHolidaysExplanation": "When the calendar passes notes with the given note category, the merchant's inventory will be refreshed. This happens on the note's time, or at midnight if it is a note that is set to all day.",
           "PriceModifierTitle": "Buy and Sell Price Modifiers",
-          "PriceModifierExplanation": "This configures the modifiers for the cost of every item in the shop. You can also configure modifiers per item type, and even for specific characters (such as silver-tongued bards). You are not limited to 200%, type into the field to go even higher.",
+          "PriceModifierExplanation": "This configures the modifiers for the cost of every item in the shop. You can also configure modifiers per item type, per specific item, and even for specific characters (such as silver-tongued bards). You are not limited to 200%, type into the field to go even higher.",
           "BuyPriceModifier": "Buy Price Modifier (%)",
           "SellPriceModifier": "Sell Price Modifier (%)",
           "ItemTypeModifier": "Item Type Price Modifiers",
           "ItemTypeModifiersExplanation": "In this dialog you can configure price modifiers for individual item types.",
           "ConfigureItemTypePriceModifiers": "Configure Item Type Price Modifiers",
+          "ItemPriceModifiers": "Item Price Modifiers",
+          "ItemPriceModifiersExplanation": "In this dialog you can configure price modifiers for specific items.",
+          "ConfigureItemPriceModifiers": "Configure Item Price Modifiers",
           "ActorPriceModifiers": "Per-Actor Override Price Modifiers",
           "ActorPriceModifiersExplanation": "Here you can configure if certain specific actors should have different price modifiers than the price modifiers above.",
           "ConfigureActorPriceModifiers": "Configure Actor Price Modifiers",

--- a/languages/zh_Hans.json
+++ b/languages/zh_Hans.json
@@ -233,7 +233,9 @@
           "OpenStatusOpen": "营业中",
           "OpenStatusClosed": "关闭",
           "ItemTypeModifier": "物品类型价格调整器",
+          "ItemPriceModifiers": "物品价格调整器",
           "ActorPriceModifiers": "特定角色覆盖价格调整器",
+          "ConfigureItemPriceModifiers": "配置物品价格调整器",
           "ConfigureActorPriceModifiers": "配置角色价格调整器",
           "EnabledExplanation": "玩家不能从商人那里拿起物品，而必须购买它们",
           "HideNewItemsExplanation": "启用后，任何卖给这个商人的物品将被隐藏。",
@@ -245,10 +247,11 @@
           "RefreshItemsHolidaysExplanation": "当日历经过给定笔记类别的笔记时，商人的库存将被刷新。这发生在笔记的时间，或者如果它是全天笔记，则在午夜发生。",
           "RefreshItemsDaysExplanation": "当日历超过选中的日子时，商人的库存将被刷新。这发生在商人的开放时间，或者如果没有开/关时间，则在午夜发生。",
           "PriceModifierTitle": "购买和销售价格调整器",
-          "PriceModifierExplanation": "配置商店中每个物品成本的调整器。你也可以为个别物品类型配置调整器，甚至为特定角色（如银舌吟游诗人）。你不仅限于200%，输入字段中的值甚至可以更高。",
+          "PriceModifierExplanation": "配置商店中每个物品成本的调整器。你也可以为个别物品类型、具体物品，甚至特定角色（如银舌吟游诗人）配置调整器。你不仅限于200%，输入字段中的值甚至可以更高。",
           "BuyPriceModifier": "购买价格调整器（%）",
           "SellPriceModifier": "销售价格调整器（%）",
           "ItemTypeModifiersExplanation": "在这个对话框中，你可以配置个别物品类型的价格调整器。",
+          "ItemPriceModifiersExplanation": "在这个对话框中，你可以为具体物品配置价格调整器。",
           "ActorPriceModifiersExplanation": "在这里，你可以配置是否某些特定角色应该有不同于上述价格调整器的不同价格调整器。",
           "MerchantColumns": "商人列",
           "MerchantColumnsExplanation": "在这里，你可以配置这个商人的系统特定列，显示在其商人UI中，如物品的稀有度。",
@@ -471,12 +474,20 @@
         "Explanation": "在这里，你可以为这个商人定义特定物品类型的价格和销售价格调整器。\"覆盖\" 设置意味着它覆盖了商人的正常价格调整器。",
         "Override": "覆盖"
       },
+      "ItemPriceModifiersEditor": {
+        "Title": "物品价格调整编辑器",
+        "TitleActor": "物品价格调整编辑器：{actor_name}",
+        "DragDrop": "拖放一个物品以将其添加到列表中",
+        "Item": "物品",
+        "Explanation": "在这里，你可以为这个商人定义与特定物品相关的购买和销售价格调整器。\"覆盖\" 设置意味着它会覆盖商人的常规价格调整器，包括按物品类型配置的价格调整器。",
+        "Override": "覆盖"
+      },
       "PriceModifiersEditor": {
         "Title": "物品堆价格调整编辑器",
         "TitleActor": "物品堆价格调整编辑器：{actor_name}",
         "DragDrop": "拖放一个角色以将其添加到列表中",
         "Actor": "角色",
-        "Explanation": "在这里，你可以为这个商人定义与特定角色相关的价格和销售价格调整器。\"覆盖\" 设置意味着它覆盖了商人的正常价格调整器，包括特定物品类型的价格调整器。",
+        "Explanation": "在这里，你可以为这个商人定义与特定角色相关的价格和销售价格调整器。\"覆盖\" 设置意味着它覆盖了商人的正常价格调整器，包括按物品类型和按具体物品配置的价格调整器。",
         "Override": "覆盖"
       },
       "SplitItem": {

--- a/src/applications/editors/index.js
+++ b/src/applications/editors/index.js
@@ -1,5 +1,6 @@
 import { CurrenciesEditor, SecondaryCurrenciesEditor } from "./currencies-editor/currencies-editor.js";
 import ItemFiltersEditor from "./item-filters-editor/item-filters-editor.js";
+import ItemPriceModifiersEditor from "./item-price-modifiers-editor/item-price-modifiers-editor.js";
 import StringListEditor from "./string-list-editor/string-list-editor.js";
 import PriceModifiersEditor from "./price-modifiers-editor/price-modifiers-editor.js";
 import PricePresetEditor from "./price-preset-editor/price-preset-editor.js";
@@ -11,6 +12,7 @@ export default {
 	"currencies": CurrenciesEditor,
 	"secondary-currencies": SecondaryCurrenciesEditor,
 	"item-filters": ItemFiltersEditor,
+	"item-price-modifiers": ItemPriceModifiersEditor,
 	"item-similarities": StringListEditor,
 	"item-categories": StringListEditor,
 	"styles": StylesEditor,

--- a/src/applications/editors/item-price-modifiers-editor/item-price-modifiers-editor.js
+++ b/src/applications/editors/item-price-modifiers-editor/item-price-modifiers-editor.js
@@ -1,0 +1,14 @@
+import ItemPriceModifiersEditorShell from './item-price-modifiers-editor.svelte';
+import Editor from "../Editor.js";
+
+export default class ItemPriceModifiersEditor extends Editor {
+	static get defaultOptions() {
+		return foundry.utils.mergeObject(super.defaultOptions, {
+			title: game.i18n.localize("ITEM-PILES.Applications.ItemPriceModifiersEditor.Title"),
+			width: 600,
+			svelte: {
+				class: ItemPriceModifiersEditorShell
+			}
+		})
+	}
+}

--- a/src/applications/editors/item-price-modifiers-editor/item-price-modifiers-editor.svelte
+++ b/src/applications/editors/item-price-modifiers-editor/item-price-modifiers-editor.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { getContext } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 	import { localize } from '#runtime/util/i18n';
 	import SliderInput from "../../components/SliderInput.svelte";
 	import { ApplicationShell } from "#runtime/svelte/component/application";
@@ -14,9 +14,9 @@
 	export let data = [];
 	export let elementRoot;
 
-	function getStoredItem(priceData) {
+	async function getStoredItem(priceData) {
 		if (priceData.uuid) {
-			const uuidItem = foundry.utils.fromUuidSync(priceData.uuid);
+			const uuidItem = await foundry.utils.fromUuid(priceData.uuid);
 			if (uuidItem) {
 				return uuidItem;
 			}
@@ -30,10 +30,10 @@
 		return new Item.implementation(foundry.utils.deepClone(itemData));
 	}
 
-	function hydrateModifier(priceData) {
-		const item = getStoredItem(priceData);
+	async function hydrateModifier(priceData) {
+		const item = await getStoredItem(priceData);
 
-		if (!item) {
+		if (!item?.toObject) {
 			return false;
 		}
 
@@ -47,7 +47,11 @@
 		};
 	}
 
-	const itemPriceModifiers = writable(data.map(hydrateModifier).filter(Boolean));
+	const itemPriceModifiers = writable([]);
+
+	onMount(async () => {
+		itemPriceModifiers.set((await Promise.all(data.map(hydrateModifier))).filter(Boolean));
+	});
 
 	function remove(index) {
 		itemPriceModifiers.update(val => {
@@ -94,7 +98,7 @@
 		itemPriceModifiers.update(val => {
 
 			const existingIndex = val.findIndex(existingPriceData => {
-				return Utilities.areItemsSimilar(existingPriceData.itemData, itemData);
+				return existingPriceData.itemData && !Utilities.areItemsDifferent(existingPriceData.itemData, itemData);
 			});
 
 			if (existingIndex !== -1) {

--- a/src/applications/editors/item-price-modifiers-editor/item-price-modifiers-editor.svelte
+++ b/src/applications/editors/item-price-modifiers-editor/item-price-modifiers-editor.svelte
@@ -1,0 +1,234 @@
+<script>
+	import { getContext } from 'svelte';
+	import { localize } from '#runtime/util/i18n';
+	import SliderInput from "../../components/SliderInput.svelte";
+	import { ApplicationShell } from "#runtime/svelte/component/application";
+	import { get, writable } from "svelte/store";
+	import * as Utilities from "../../../helpers/utilities.js";
+	import * as CompendiumUtilities from "../../../helpers/compendium-utilities.js";
+
+	const { application } = getContext('#external');
+
+	let form;
+
+	export let data = [];
+	export let elementRoot;
+
+	function getStoredItem(priceData) {
+		if (priceData.uuid) {
+			const uuidItem = foundry.utils.fromUuidSync(priceData.uuid);
+			if (uuidItem) {
+				return uuidItem;
+			}
+		}
+
+		const itemData = priceData.itemData ?? priceData.item;
+		if (!itemData) {
+			return false;
+		}
+
+		return new Item.implementation(foundry.utils.deepClone(itemData));
+	}
+
+	function hydrateModifier(priceData) {
+		const item = getStoredItem(priceData);
+
+		if (!item) {
+			return false;
+		}
+
+		return {
+			override: false,
+			buyPriceModifier: 1,
+			sellPriceModifier: 0.5,
+			...foundry.utils.deepClone(priceData),
+			itemData: item.toObject(),
+			item
+		};
+	}
+
+	const itemPriceModifiers = writable(data.map(hydrateModifier).filter(Boolean));
+
+	function remove(index) {
+		itemPriceModifiers.update(val => {
+			val.splice(index, 1)
+			return val;
+		})
+	}
+
+	async function updateSettings() {
+		const result = get(itemPriceModifiers).map(priceData => {
+			const data = foundry.utils.deepClone(priceData);
+			data.itemData = priceData.item.toObject();
+			delete data.item;
+			return data;
+		});
+		application.options.resolve?.(result);
+		application.close();
+	}
+
+	export function requestSubmit() {
+		form.requestSubmit();
+	}
+
+	async function dropData(event) {
+
+		event.preventDefault();
+
+		let data;
+		try {
+			data = JSON.parse(event.dataTransfer.getData('text/plain'));
+		} catch (err) {
+			return false;
+		}
+
+		if (data.type !== "Item") return;
+
+		const item = await Item.implementation.fromDropData(data);
+
+		if (!item) return;
+
+		const itemData = item.toObject();
+		const uuid = item.pack ? item.uuid : (await CompendiumUtilities.findOrCreateItemInCompendium(itemData)).uuid;
+
+		itemPriceModifiers.update(val => {
+
+			const existingIndex = val.findIndex(existingPriceData => {
+				return Utilities.areItemsSimilar(existingPriceData.itemData, itemData);
+			});
+
+			if (existingIndex !== -1) {
+				val[existingIndex].uuid = uuid;
+				val[existingIndex].itemData = itemData;
+				val[existingIndex].item = item;
+				return val;
+			}
+
+			val.push({
+				override: false,
+				item,
+				itemData,
+				uuid,
+				buyPriceModifier: 1,
+				sellPriceModifier: 0.5
+			});
+
+			return val;
+
+		})
+	}
+
+	async function editItem(priceData) {
+		let item = priceData.uuid ? await foundry.utils.fromUuid(priceData.uuid) : false;
+		if (!item) {
+			item = new Item.implementation(foundry.utils.deepClone(priceData.itemData));
+		}
+		item.sheet.render(true);
+	}
+
+	function preventDefault(event) {
+		event.preventDefault();
+	}
+
+</script>
+
+<svelte:options accessors={true}/>
+
+<ApplicationShell bind:elementRoot>
+
+	<form autocomplete=off bind:this={form} on:submit|preventDefault={updateSettings}>
+
+		<p>{localize("ITEM-PILES.Applications.ItemPriceModifiersEditor.Explanation")}</p>
+
+		<div class:border-highlight={!$itemPriceModifiers.length} on:dragover={preventDefault} on:dragstart={preventDefault}
+		     on:drop={dropData}>
+
+			{#if $itemPriceModifiers.length}
+				<table>
+					<tr>
+						<th style="width:5%;">{localize("ITEM-PILES.Applications.ItemPriceModifiersEditor.Override")}</th>
+						<th style="width:25%;">{localize("ITEM-PILES.Applications.ItemPriceModifiersEditor.Item")}</th>
+						<th style="width:35%;">{localize("ITEM-PILES.Applications.ItemPileConfig.Merchant.BuyPriceModifier")}</th>
+						<th style="width:35%;">{localize("ITEM-PILES.Applications.ItemPileConfig.Merchant.SellPriceModifier")}</th>
+						<th style="width:5%;"></th>
+					</tr>
+					{#each $itemPriceModifiers as priceData, index (index)}
+						<tr>
+							<td>
+								<div class="form-group">
+									<input type="checkbox" bind:checked={priceData.override}>
+								</div>
+							</td>
+							<td>
+								<a class="item-piles-actor-name-clickable"
+								   on:click={() => editItem(priceData)}>{priceData.item.name}</a>
+							</td>
+							<td>
+								<div class="item-piles-flexrow" style="margin: 0 0.25rem">
+									<SliderInput bind:value={priceData.buyPriceModifier}/>
+								</div>
+							</td>
+							<td>
+								<div class="item-piles-flexrow" style="margin: 0 0.25rem">
+									<SliderInput bind:value={priceData.sellPriceModifier}/>
+								</div>
+							</td>
+							<td class="small">
+								<button type="button" on:click={remove(index)}><i class="fas fa-times"></i></button>
+							</td>
+						</tr>
+					{/each}
+				</table>
+			{/if}
+
+			<p class="item-piles-text-center">{localize("ITEM-PILES.Applications.ItemPriceModifiersEditor.DragDrop")}</p>
+
+		</div>
+
+		<footer>
+			<button on:click|once={requestSubmit} type="button">
+				<i class="far fa-save"></i> {localize("Save")}
+			</button>
+			<button on:click|once={() => { application.close(); }} type="button">
+				<i class="far fa-times"></i> { localize("Cancel") }
+			</button>
+		</footer>
+
+	</form>
+
+</ApplicationShell>
+
+
+<style lang="scss">
+
+  .border-highlight {
+    padding: 1rem;
+    margin: 0.25rem;
+    border-radius: 10px;
+    border: 2px dashed gray;
+  }
+
+  table {
+    vertical-align: middle;
+
+    tr {
+      border-spacing: 15px;
+    }
+
+    .small {
+      width: 26px;
+    }
+
+    button {
+      padding: 0.25rem 0.25rem;
+      line-height: 1rem;
+      flex: 0;
+      text-align: center;
+    }
+
+    a {
+      text-align: center;
+    }
+  }
+
+</style>

--- a/src/applications/item-pile-config/settings/merchant.svelte
+++ b/src/applications/item-pile-config/settings/merchant.svelte
@@ -2,6 +2,8 @@
 
 	import ItemTypePriceModifiersEditor
 		from "../../editors/item-type-price-modifiers-editor/item-type-price-modifiers-editor.js";
+	import ItemPriceModifiersEditor
+		from "../../editors/item-price-modifiers-editor/item-price-modifiers-editor.js";
 	import PriceModifiersEditor from "../../editors/price-modifiers-editor/price-modifiers-editor.js";
 	import FilePicker from "../../components/FilePicker.svelte";
 	import SliderInput from "../../components/SliderInput.svelte";
@@ -74,6 +76,22 @@
 					delete modifier['actor'];
 				}
 			})
+		});
+	}
+
+	async function showItemPriceModifiers() {
+		const data = pileData.itemPriceModifiers || [];
+		return ItemPriceModifiersEditor.show(
+			data,
+			{ id: `item-price-modifier-item-pile-config-${pileActor.id}` },
+			{ title: localize("ITEM-PILES.Applications.ItemPriceModifiersEditor.TitleActor", { actor_name: pileActor.name }), }
+		).then((result) => {
+			pileData.itemPriceModifiers = result || [];
+			pileData.itemPriceModifiers.forEach(modifier => {
+				if (modifier.item) {
+					delete modifier["item"];
+				}
+			});
 		});
 	}
 
@@ -260,6 +278,18 @@
 		</label>
 		<button on:click={() => { showItemTypePriceModifiers() }} type="button">
 			{localize("ITEM-PILES.Applications.ItemPileConfig.Merchant.ConfigureItemTypePriceModifiers")}
+		</button>
+	</div>
+</div>
+
+<div class="form-group">
+	<div class="item-piles-flexcol">
+		<label>
+			<span>{localize("ITEM-PILES.Applications.ItemPileConfig.Merchant.ItemPriceModifiers")}</span>
+			<p>{localize("ITEM-PILES.Applications.ItemPileConfig.Merchant.ItemPriceModifiersExplanation")}</p>
+		</label>
+		<button on:click={() => { showItemPriceModifiers() }} type="button">
+			{localize("ITEM-PILES.Applications.ItemPileConfig.Merchant.ConfigureItemPriceModifiers")}
 		</button>
 	</div>
 </div>

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -197,6 +197,7 @@ const CONSTANTS = {
 		buyPriceModifier: 1,
 		sellPriceModifier: 0.5,
 		itemTypePriceModifiers: [],
+		itemPriceModifiers: [],
 		actorPriceModifiers: [],
 		tablesForPopulate: [],
 		merchantColumns: [],

--- a/src/helpers/pile-utilities.js
+++ b/src/helpers/pile-utilities.js
@@ -856,7 +856,7 @@ export function getMerchantModifiersForActor(merchant, {
 } = {}) {
 
 	let {
-		buyPriceModifier, sellPriceModifier, itemTypePriceModifiers, actorPriceModifiers
+		buyPriceModifier, sellPriceModifier, itemTypePriceModifiers, itemPriceModifiers, actorPriceModifiers
 	} = getActorFlagData(merchant, { data: pileFlagData });
 
 	if (item) {
@@ -884,6 +884,23 @@ export function getMerchantModifiersForActor(merchant, {
 				? itemTypePriceModifier.sellPriceModifier ?? sellPriceModifier
 				: sellPriceModifier * itemTypePriceModifier.sellPriceModifier;
 		}
+
+		const itemPriceModifier = itemPriceModifiers.find(priceData => {
+			const storedItem = priceData.itemData
+				?? priceData.item
+				?? (priceData.uuid
+					? CompendiumUtilities.getItemFromCache(priceData.uuid) ?? foundry.utils.fromUuidSync(priceData.uuid)?.toObject()
+					: false);
+			return Utilities.areItemsSimilar(storedItem, item);
+		});
+		if (itemPriceModifier) {
+			buyPriceModifier = itemPriceModifier.override
+				? itemPriceModifier.buyPriceModifier ?? buyPriceModifier
+				: buyPriceModifier * itemPriceModifier.buyPriceModifier;
+			sellPriceModifier = itemPriceModifier.override
+				? itemPriceModifier.sellPriceModifier ?? sellPriceModifier
+				: sellPriceModifier * itemPriceModifier.sellPriceModifier;
+		}
 	}
 
 	if (actor && actorPriceModifiers) {
@@ -900,7 +917,7 @@ export function getMerchantModifiersForActor(merchant, {
 
 	if (SYSTEMS.DATA.PRICE_MODIFIER_TRANSFORMER && !absolute) {
 		const modifiers = SYSTEMS.DATA.PRICE_MODIFIER_TRANSFORMER({
-			buyPriceModifier, sellPriceModifier, merchant, item, actor, actorPriceModifiers
+			buyPriceModifier, sellPriceModifier, merchant, item, actor, itemPriceModifiers, actorPriceModifiers
 		});
 		buyPriceModifier = modifiers.buyPriceModifier;
 		sellPriceModifier = modifiers.sellPriceModifier;

--- a/src/helpers/pile-utilities.js
+++ b/src/helpers/pile-utilities.js
@@ -891,7 +891,7 @@ export function getMerchantModifiersForActor(merchant, {
 				?? (priceData.uuid
 					? CompendiumUtilities.getItemFromCache(priceData.uuid) ?? foundry.utils.fromUuidSync(priceData.uuid)?.toObject()
 					: false);
-			return Utilities.areItemsSimilar(storedItem, item);
+			return storedItem && !Utilities.areItemsDifferent(storedItem, item);
 		});
 		if (itemPriceModifier) {
 			buyPriceModifier = itemPriceModifier.override

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -116,37 +116,6 @@ export function findSimilarItem(items, findItem, {
 
 }
 
-export function areItemsSimilar(itemA, itemB) {
-
-	let itemAData = itemA instanceof Item ? itemA.toObject() : itemA;
-	itemAData = itemAData?.item ?? itemAData;
-
-	let itemBData = itemB instanceof Item ? itemB.toObject() : itemB;
-	itemBData = itemBData?.item ?? itemBData;
-
-	if (!itemAData || !itemBData) {
-		return false;
-	}
-
-	const itemAId = itemA instanceof Item ? itemA.id : itemA?.item?._id ?? itemAData?._id ?? itemA?.id;
-	const itemBId = itemB instanceof Item ? itemB.id : itemB?.item?._id ?? itemBData?._id ?? itemB?.id;
-
-	if (itemAId && itemBId && itemAId === itemBId) {
-		return true;
-	}
-
-	const itemSimilarities = game.itempiles.API.ITEM_SIMILARITIES;
-
-	if (!itemSimilarities.length || !itemSimilarities.some(path => {
-		return foundry.utils.hasProperty(itemAData, path) || foundry.utils.hasProperty(itemBData, path);
-	})) {
-		return false;
-	}
-
-	return !areItemsDifferent(itemAData, itemBData);
-
-}
-
 export function areItemsDifferent(itemA, itemB) {
 	const itemSimilarities = game.itempiles.API.ITEM_SIMILARITIES;
 	for (const path of itemSimilarities) {

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -116,6 +116,37 @@ export function findSimilarItem(items, findItem, {
 
 }
 
+export function areItemsSimilar(itemA, itemB) {
+
+	let itemAData = itemA instanceof Item ? itemA.toObject() : itemA;
+	itemAData = itemAData?.item ?? itemAData;
+
+	let itemBData = itemB instanceof Item ? itemB.toObject() : itemB;
+	itemBData = itemBData?.item ?? itemBData;
+
+	if (!itemAData || !itemBData) {
+		return false;
+	}
+
+	const itemAId = itemA instanceof Item ? itemA.id : itemA?.item?._id ?? itemAData?._id ?? itemA?.id;
+	const itemBId = itemB instanceof Item ? itemB.id : itemB?.item?._id ?? itemBData?._id ?? itemB?.id;
+
+	if (itemAId && itemBId && itemAId === itemBId) {
+		return true;
+	}
+
+	const itemSimilarities = game.itempiles.API.ITEM_SIMILARITIES;
+
+	if (!itemSimilarities.length || !itemSimilarities.some(path => {
+		return foundry.utils.hasProperty(itemAData, path) || foundry.utils.hasProperty(itemBData, path);
+	})) {
+		return false;
+	}
+
+	return !areItemsDifferent(itemAData, itemBData);
+
+}
+
 export function areItemsDifferent(itemA, itemB) {
 	const itemSimilarities = game.itempiles.API.ITEM_SIMILARITIES;
 	for (const path of itemSimilarities) {


### PR DESCRIPTION
Introduce per-item price modifier support and UI.

- Add a new Item Price Modifiers editor (JS + Svelte) to create/edit per-item buy/sell modifiers with drag-and-drop and slider controls.
- Register the editor in the editors index.
- Add i18n strings for English and Simplified Chinese and tweak related price modifier descriptions.
- Wire editor into merchant settings: add button, showItemPriceModifiers handler, and save/cleanup logic (remove transient item objects before persisting).
- Add itemPriceModifiers default to constants.
- Add areItemsSimilar utility and update pile-utilities to apply item-specific modifiers (including passing itemPriceModifiers to price-transformer hook).

Purpose: allow merchants to override or adjust pricing for specific items in addition to item-type and actor-based modifiers. 

https://github.com/fantasycalendar/FoundryVTT-ItemPiles/issues/454

------

不好意思，我见这个需求一直没有动静，因此使用copilot实现了这样的功能。

Sorry, I noticed this request hadn't been addressed, so I used Copilot to implement this feature.