### PR TITLE
Fix item being locked with a highlight when moving or clicking inside a recipient/container

### DIFF
--- a/src/applications/components/Grid/GridItem.svelte
+++ b/src/applications/components/Grid/GridItem.svelte
@@ -271,6 +271,8 @@
 
 		if (!active) return;
 
+		activeStore.set(false);
+
 		for (const otherItem of items) {
 			if (activeOtherIds.has(otherItem.id)) {
 				otherItem.active.set(false);

--- a/src/foundry-ui-overrides.js
+++ b/src/foundry-ui-overrides.js
@@ -334,7 +334,15 @@ class FastTooltipManager extends (foundry?.helpers?.interaction?.TooltipManager?
 		this._setAnchor(direction);
 	}
 
-	/* -------------------------------------------- */
+	deactivate() {
+		this.#active = false;
+		this.tooltip.classList.remove("active");
+		this.tooltip.innerHTML = "";
+		if (this.element) {
+			this.element.removeAttribute("aria-describedby");
+			this.element = null;
+		}
+	}
 
 	/**
 	 * Handle hover events which deactivate a tooltipped element.


### PR DESCRIPTION
Fix vault items getting permanently locked in active/highlighted state when clicked or dragged by resetting the active store on drag end and overriding the tooltip deactivation to avoid calling hidePopover() on a non-popover element.